### PR TITLE
MULE-13255: Invalid versioning for Mule Module Maven Plugin

### DIFF
--- a/src/test/projects/annotation/exportedRuntimeAnnotationInPublicClass/pom.xml
+++ b/src/test/projects/annotation/exportedRuntimeAnnotationInPublicClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/exportedRuntimeAnnotationInPublicField/pom.xml
+++ b/src/test/projects/annotation/exportedRuntimeAnnotationInPublicField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/exportedRuntimeAnnotationInPublicMethod/pom.xml
+++ b/src/test/projects/annotation/exportedRuntimeAnnotationInPublicMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/exportedRuntimeAnnotationInPublicMethodParam/pom.xml
+++ b/src/test/projects/annotation/exportedRuntimeAnnotationInPublicMethodParam/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresCompileAnnotationInPublicClass/pom.xml
+++ b/src/test/projects/annotation/ignoresCompileAnnotationInPublicClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresCompileAnnotationInPublicField/pom.xml
+++ b/src/test/projects/annotation/ignoresCompileAnnotationInPublicField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresCompileAnnotationInPublicMethod/pom.xml
+++ b/src/test/projects/annotation/ignoresCompileAnnotationInPublicMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresCompileAnnotationInPublicMethodParam/pom.xml
+++ b/src/test/projects/annotation/ignoresCompileAnnotationInPublicMethodParam/pom.xml
@@ -8,10 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Empty Project</name>
-
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+    
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresRuntimeAnnotationInPackageClass/pom.xml
+++ b/src/test/projects/annotation/ignoresRuntimeAnnotationInPackageClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresRuntimeAnnotationInPackageField/pom.xml
+++ b/src/test/projects/annotation/ignoresRuntimeAnnotationInPackageField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresRuntimeAnnotationInPackageMethod/pom.xml
+++ b/src/test/projects/annotation/ignoresRuntimeAnnotationInPackageMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresRuntimeAnnotationInPackageMethodParam/pom.xml
+++ b/src/test/projects/annotation/ignoresRuntimeAnnotationInPackageMethodParam/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresRuntimeAnnotationInPublicMethodParam/pom.xml
+++ b/src/test/projects/annotation/ignoresRuntimeAnnotationInPublicMethodParam/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresSourceAnnotationInPublicClass/pom.xml
+++ b/src/test/projects/annotation/ignoresSourceAnnotationInPublicClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresSourceAnnotationInPublicField/pom.xml
+++ b/src/test/projects/annotation/ignoresSourceAnnotationInPublicField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresSourceAnnotationInPublicMethod/pom.xml
+++ b/src/test/projects/annotation/ignoresSourceAnnotationInPublicMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/ignoresSourceAnnotationInPublicMethodParam/pom.xml
+++ b/src/test/projects/annotation/ignoresSourceAnnotationInPublicMethodParam/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/missingRuntimeAnnotationInPublicClass/pom.xml
+++ b/src/test/projects/annotation/missingRuntimeAnnotationInPublicClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/missingRuntimeAnnotationInPublicField/pom.xml
+++ b/src/test/projects/annotation/missingRuntimeAnnotationInPublicField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/missingRuntimeAnnotationInPublicMethod/pom.xml
+++ b/src/test/projects/annotation/missingRuntimeAnnotationInPublicMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/annotation/missingRuntimeAnnotationInPublicMethodParam/pom.xml
+++ b/src/test/projects/annotation/missingRuntimeAnnotationInPublicMethodParam/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/class/exportedSuperClassInProtectedInnerClass/pom.xml
+++ b/src/test/projects/class/exportedSuperClassInProtectedInnerClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/class/exportedSuperClassInPublicClass/pom.xml
+++ b/src/test/projects/class/exportedSuperClassInPublicClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/class/ignoresSuperClassInPackageClass/pom.xml
+++ b/src/test/projects/class/ignoresSuperClassInPackageClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/class/ignoresSuperClassInPrivateInnerClass/pom.xml
+++ b/src/test/projects/class/ignoresSuperClassInPrivateInnerClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/class/missingSuperClassInProtectedInnerClass/pom.xml
+++ b/src/test/projects/class/missingSuperClassInProtectedInnerClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/class/missingSuperClassInPublicClass/pom.xml
+++ b/src/test/projects/class/missingSuperClassInPublicClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/code/ignoresTypeReferenceInMethod/pom.xml
+++ b/src/test/projects/code/ignoresTypeReferenceInMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/code/ignoresTypeReferenceInStaticInitializer/pom.xml
+++ b/src/test/projects/code/ignoresTypeReferenceInStaticInitializer/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/field/exportedProtectedInstanceField/pom.xml
+++ b/src/test/projects/field/exportedProtectedInstanceField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/field/exportedPublicInstanceField/pom.xml
+++ b/src/test/projects/field/exportedPublicInstanceField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/field/ignoresPackageInstanceField/pom.xml
+++ b/src/test/projects/field/ignoresPackageInstanceField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/field/ignoresPrivateInstanceField/pom.xml
+++ b/src/test/projects/field/ignoresPrivateInstanceField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/field/ignoresProtectedInstanceFieldInFinalClass/pom.xml
+++ b/src/test/projects/field/ignoresProtectedInstanceFieldInFinalClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/field/missingProtectedInstanceField/pom.xml
+++ b/src/test/projects/field/missingProtectedInstanceField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/field/missingPublicInstanceField/pom.xml
+++ b/src/test/projects/field/missingPublicInstanceField/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/exportedInterfaceInProtectedInnerClass/pom.xml
+++ b/src/test/projects/interface/exportedInterfaceInProtectedInnerClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/exportedInterfaceInPublicClass/pom.xml
+++ b/src/test/projects/interface/exportedInterfaceInPublicClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/exportedSuperInterfaceInProtectedInnerInterface/pom.xml
+++ b/src/test/projects/interface/exportedSuperInterfaceInProtectedInnerInterface/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/exportedSuperInterfaceInPublicInterface/pom.xml
+++ b/src/test/projects/interface/exportedSuperInterfaceInPublicInterface/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/ignoresInterfaceInPackageClass/pom.xml
+++ b/src/test/projects/interface/ignoresInterfaceInPackageClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/ignoresInterfaceInPrivateInnerClass/pom.xml
+++ b/src/test/projects/interface/ignoresInterfaceInPrivateInnerClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/ignoresSuperInterfaceInPackageInterface/pom.xml
+++ b/src/test/projects/interface/ignoresSuperInterfaceInPackageInterface/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/ignoresSuperInterfaceInPrivateInnerInterface/pom.xml
+++ b/src/test/projects/interface/ignoresSuperInterfaceInPrivateInnerInterface/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/missingInterfaceInProtectedInnerClass/pom.xml
+++ b/src/test/projects/interface/missingInterfaceInProtectedInnerClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/missingInterfaceInPublicClass/pom.xml
+++ b/src/test/projects/interface/missingInterfaceInPublicClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/missingSuperInterfaceInProtectedInnerInterface/pom.xml
+++ b/src/test/projects/interface/missingSuperInterfaceInProtectedInnerInterface/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/interface/missingSuperInterfaceInPublicInterface/pom.xml
+++ b/src/test/projects/interface/missingSuperInterfaceInPublicInterface/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/miscellaneous/ignoresJreExportedPackage/pom.xml
+++ b/src/test/projects/miscellaneous/ignoresJreExportedPackage/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/miscellaneous/redundantExportedPackage/pom.xml
+++ b/src/test/projects/miscellaneous/redundantExportedPackage/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/module/detectsExportedOptionalPackageFromLibrary/pom.xml
+++ b/src/test/projects/module/detectsExportedOptionalPackageFromLibrary/pom.xml
@@ -15,9 +15,7 @@
     </modules>
 
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/module/exportsPackageFromLibrary/pom.xml
+++ b/src/test/projects/module/exportsPackageFromLibrary/pom.xml
@@ -15,9 +15,7 @@
     </modules>
 
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/module/ignoresOptionalPackageFromLibrary/pom.xml
+++ b/src/test/projects/module/ignoresOptionalPackageFromLibrary/pom.xml
@@ -15,9 +15,7 @@
     </modules>
 
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/module/missingExportsPackageFromLibrary/pom.xml
+++ b/src/test/projects/module/missingExportsPackageFromLibrary/pom.xml
@@ -15,9 +15,7 @@
     </modules>
 
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/module/noExportsPackageFromModule/pom.xml
+++ b/src/test/projects/module/noExportsPackageFromModule/pom.xml
@@ -15,9 +15,7 @@
     </modules>
 
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/module/redundantExportPackageFromModule/pom.xml
+++ b/src/test/projects/module/redundantExportPackageFromModule/pom.xml
@@ -14,11 +14,6 @@
         <module>fooModule</module>
     </modules>
 
-
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
-
     <build>
         <pluginManagement>
             <plugins>

--- a/src/test/projects/parameter/exportedParameterInProtectedMethod/pom.xml
+++ b/src/test/projects/parameter/exportedParameterInProtectedMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/parameter/exportedParameterInPublicMethod/pom.xml
+++ b/src/test/projects/parameter/exportedParameterInPublicMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/parameter/ignoresParameterInPackageMethod/pom.xml
+++ b/src/test/projects/parameter/ignoresParameterInPackageMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/parameter/ignoresParameterInPrivateMethod/pom.xml
+++ b/src/test/projects/parameter/ignoresParameterInPrivateMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/parameter/ignoresParameterInProtectedMethodFromFinalClass/pom.xml
+++ b/src/test/projects/parameter/ignoresParameterInProtectedMethodFromFinalClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/parameter/missingParameterInProtectedMethod/pom.xml
+++ b/src/test/projects/parameter/missingParameterInProtectedMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/parameter/missingParameterInPublicMethod/pom.xml
+++ b/src/test/projects/parameter/missingParameterInPublicMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/privileged/duplicatedExportInPrivilegedApi/pom.xml
+++ b/src/test/projects/privileged/duplicatedExportInPrivilegedApi/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/privileged/exportInPrivilegedApi/pom.xml
+++ b/src/test/projects/privileged/exportInPrivilegedApi/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/privileged/missingExportInPrivilegedApi/pom.xml
+++ b/src/test/projects/privileged/missingExportInPrivilegedApi/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/privileged/noPrivilegedExportPackageFromModule/pom.xml
+++ b/src/test/projects/privileged/noPrivilegedExportPackageFromModule/pom.xml
@@ -15,9 +15,7 @@
     </modules>
 
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/privileged/redundantPrivilegedExportPackageFromModule/pom.xml
+++ b/src/test/projects/privileged/redundantPrivilegedExportPackageFromModule/pom.xml
@@ -15,9 +15,7 @@
     </modules>
 
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/return/exportedReturnInProtectedMethod/pom.xml
+++ b/src/test/projects/return/exportedReturnInProtectedMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/return/exportedReturnInPublicMethod/pom.xml
+++ b/src/test/projects/return/exportedReturnInPublicMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/return/ignoresReturnInPackageMethod/pom.xml
+++ b/src/test/projects/return/ignoresReturnInPackageMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/return/ignoresReturnInPrivateMethod/pom.xml
+++ b/src/test/projects/return/ignoresReturnInPrivateMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/return/ignoresReturnInProtectedMethodFromFinalClass/pom.xml
+++ b/src/test/projects/return/ignoresReturnInProtectedMethodFromFinalClass/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/return/missingReturnInProtectedMethod/pom.xml
+++ b/src/test/projects/return/missingReturnInProtectedMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>

--- a/src/test/projects/return/missingReturnInPublicMethod/pom.xml
+++ b/src/test/projects/return/missingReturnInPublicMethod/pom.xml
@@ -9,9 +9,7 @@
     <packaging>jar</packaging>
     <name>Empty Project</name>
 
-    <properties>
-        <it-plugin.version>1.0-SNAPSHOT</it-plugin.version>
-    </properties>
+
 
     <build>
         <pluginManagement>


### PR DESCRIPTION
The property it-plugin.version is passed in every test with the project.version automatically so it is not needed to set its version.