### PR TITLE
MULE-14154: mule-module-maven-plugin crashes with some invalid .class…

### DIFF
--- a/src/main/java/org/mule/tools/maven/plugin/module/analyze/asm/DependencyClassFileVisitor.java
+++ b/src/main/java/org/mule/tools/maven/plugin/module/analyze/asm/DependencyClassFileVisitor.java
@@ -41,6 +41,11 @@ public class DependencyClassFileVisitor implements ClassFileVisitor {
    *      java.io.InputStream)
    */
   public void visitClass(String className, InputStream in) {
+    // TODO(pablo.kraan): MULE-14419 - ignoring classes defined inside META-INF folder and module-info until Java 9 is supported
+    if (className.startsWith("META-INF.") || className.equals("module-info")) {
+      return;
+    }
+
     try {
       final String packageName = getPackageName(className);
       ClassReader reader = new ClassReader(in);


### PR DESCRIPTION
… files present in META-INF

_ No test added as it will require to build using Java 9